### PR TITLE
Add support to set personas, userids, everyone access by plugin

### DIFF
--- a/CommunityPlugin/CommunityPlugin.csproj
+++ b/CommunityPlugin/CommunityPlugin.csproj
@@ -283,6 +283,7 @@
     <Compile Include="Objects\Models\FilterCDO.cs" />
     <Compile Include="Objects\Models\MailTrigger.cs" />
     <Compile Include="Objects\Models\PipelineFilter.cs" />
+    <Compile Include="Objects\Models\PluginSettings.cs" />
     <Compile Include="Objects\Models\RuleLockCDO.cs" />
     <Compile Include="Objects\Models\RuleLockInfo.cs" />
     <Compile Include="Objects\Models\HomeCounselor.cs" />

--- a/CommunityPlugin/Objects/Models/PluginSettings.cs
+++ b/CommunityPlugin/Objects/Models/PluginSettings.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace CommunityPlugin.Objects.Models
+{
+    public class PluginSettings
+    {
+        public string PluginName { get; set; }
+
+        public Permission Permissions { get; set; }
+        public Dictionary<string, JObject> Settings { get; set; }
+
+        public class Permission
+        {
+            public bool Everyone { get; set; }
+            public List<string> Personas { get; set; }
+            public List<string> UserIDs { get; set; }
+        }
+    }
+}

--- a/CommunityPlugin/Objects/Models/SettingsCDO.cs
+++ b/CommunityPlugin/Objects/Models/SettingsCDO.cs
@@ -22,5 +22,8 @@ namespace CommunityPlugin.Objects.Models
 
         [JsonProperty("Permission")]
         public Dictionary<string, List<string>> Permission { get; set; }
+
+        [JsonProperty("Plugins")]
+        public Dictionary<string, PluginSettings> Plugins { get; set; }
     }
 }

--- a/CommunityPlugin/Objects/PluginAccess.cs
+++ b/CommunityPlugin/Objects/PluginAccess.cs
@@ -12,11 +12,17 @@ namespace CommunityPlugin.Objects
     {
 
         private static readonly List<PluginAccessRight> Rights = CDOHelper.CDO.CommunitySettings.Permission["AllAccess"].Select(x => new PluginAccessRight() { AllAccess = true, PluginName = x.ToString() }).ToList();
+        private static readonly Dictionary<string, PluginSettings> Plugins = CDOHelper.CDO.CommunitySettings.Plugins;
 
+        
         public static bool CheckAccess(string pluginName, bool menu = false, bool loan = false)
         {
             if (EncompassHelper.IsTest() || CDOHelper.CDO.CommunitySettings.SuperAdminRun)
                 return true;
+
+            
+            if (Plugins != null) return CheckAccessInPlugins(pluginName, menu, loan);
+
 
             PluginAccessRight right = Rights.Where(x => x.PluginName.Equals(pluginName)).FirstOrDefault();
             if (right == null)
@@ -29,6 +35,26 @@ namespace CommunityPlugin.Objects
 
             if (!isAllowedToRun && right.UserIDs != null)
                 isAllowedToRun = right.UserIDs.Contains(EncompassHelper.User.ID);
+
+            return isAllowedToRun;
+        }
+
+        private static bool CheckAccessInPlugins(string pluginName, bool menu, bool loan)
+        {
+            if (Plugins.TryGetValue(pluginName, out var pluginSettings) == false) return false;
+
+            if (pluginSettings.Permissions == null) return false;
+
+            if (pluginSettings.Permissions.Everyone) return true;
+
+            
+            var isAllowedToRun = !loan && pluginSettings.Permissions.Everyone;
+
+            if (!isAllowedToRun && pluginSettings.Permissions.Personas != null)
+                isAllowedToRun = EncompassHelper.ContainsPersona(pluginSettings.Permissions.Personas);
+
+            if (!isAllowedToRun && pluginSettings.Permissions.UserIDs != null)
+                isAllowedToRun = pluginSettings.Permissions.UserIDs.Contains(EncompassHelper.User.ID);
 
             return isAllowedToRun;
         }

--- a/CommunitySettings.json
+++ b/CommunitySettings.json
@@ -1,5 +1,5 @@
-{	
-	"CommunitySettings":{
+{
+	"CommunitySettings": {
 		"SideMenuOpenByDefault": "False",
 		"TestServer": "TEBE11177289",
 		"SuperAdminRun": "False",
@@ -17,77 +17,172 @@
 				"GridSearch"
 			]
 		},
-		"Links": {
-			"Loan Officer": {
-				"EFolder": {
-					"Credit Report": "Credit Report"
+		"Plugins": {
+			"SideMenu": {
+				"Permissions": {
+					"Everyone": false,
+					"Personas": [
+						"Super Administrator"
+					],
+					"UserIds": []
 				},
-				"Email": {
-
-				},
-				"Form": {
-					"Trust Account": "Trust Account"
-				},
-				"Internet": {
-					"Arch": "https://ratestar.archmi.com/quote/#/login",
-					"Essent": "https://www.essent.us/"
-				},
-				"Popup": {
-					"2015 Itemization": "2015 Itemization"
-				},
-				"Pricing": {
-					"Optimal Blue": "https://www2.optimalblue.com/"
-				},
-				"Print": {
-
-				},
-				"Service": {
-					"Access Lenders": "Lenders"
-				}
+				"Settings": {}
 			},
-			"Default": {
-				"EFolder": {
-					"Credit Report": "Credit Report"
+			"AutomateInputFormSet": {
+				"Permissions": {
+					"Everyone": false,
+					"Personas": [
+						"Super Administrator"
+					],
+					"UserIds": []
 				},
-				"Email": {
-
-				},
-				"Form": {
-					"Trust Account": "Trust Account"
-				},
-				"Internet": {
-					"Arch": "https://ratestar.archmi.com/quote/#/login",
-					"Essent": "https://www.essent.us/"
-				},
-				"Popup": {
-					"2015 Itemization": "2015 Itemization"
-				},
-				"Pricing": {
-					"Optimal Blue": "https://www2.optimalblue.com/"
-				},
-				"Print": {
-
-				},
-				"Service": {
-					"Access Lenders": "Lenders"
-				}
-			}
-		},
-		"LoanInformation": {
-			"Loan Officer": {
-				"3": "",
-				"VASUMM.X23": "",
-				"1401": "",
-				"19": "",
-				"799": ""
+				"Settings": {}
 			},
-			"Default": {
-				"3": "",
-				"VASUMM.X23": "",
-				"1401": "",
-				"19": "",
-				"799": ""
+			"HCAutomate": {
+				"Permissions": {
+					"Everyone": false,
+					"Personas": [
+						"Super Administrator"
+					],
+					"UserIds": []
+				},
+				"Settings": {}
+			},
+			"KickEveryoneOut": {
+				"Permissions": {
+					"Everyone": false,
+					"Personas": [
+						"Super Administrator"
+					],
+					"UserIds": []
+				},
+				"Settings": {}
+			},
+			"OpeneFolderDocument": {
+				"Permissions": {
+					"Everyone": false,
+					"Personas": [
+						"Super Administrator"
+					],
+					"UserIds": []
+				},
+				"Settings": {}
+			},
+			"VirtualFields": {
+				"Permissions": {
+					"Everyone": false,
+					"Personas": [
+						"Super Administrator"
+					],
+					"UserIds": []
+				},
+				"Settings": {}
+			},
+			"Doorbell": {
+				"Permissions": {
+					"Everyone": false,
+					"Personas": [
+						"Super Administrator"
+					],
+					"UserIds": []
+				},
+				"Settings": {}
+			},
+			"BackAndForward": {
+				"Permissions": {
+					"Everyone": false,
+					"Personas": [
+						"Super Administrator"
+					],
+					"UserIds": []
+				},
+				"Settings": {}
+			},
+			"OpenReadOnly": {
+				"Permissions": {
+					"Everyone": false,
+					"Personas": [
+						"Super Administrator"
+					],
+					"UserIds": []
+				},
+				"Settings": {}
+			},
+			"GridSearch": {
+				"Permissions": {
+					"Everyone": false,
+					"Personas": [
+						"Super Administrator"
+					],
+					"UserIds": []
+				},
+				"Settings": {}
 			}
 		}
+	},
+	"Links": {
+		"Loan Officer": {
+			"EFolder": {
+				"Credit Report": "Credit Report"
+			},
+			"Email": {},
+			"Form": {
+				"Trust Account": "Trust Account"
+			},
+			"Internet": {
+				"Arch": "https://ratestar.archmi.com/quote/#/login",
+				"Essent": "https://www.essent.us/"
+			},
+			"Popup": {
+				"2015 Itemization": "2015 Itemization"
+			},
+			"Pricing": {
+				"Optimal Blue": "https://www2.optimalblue.com/"
+			},
+			"Print": {},
+			"Service": {
+				"Access Lenders": "Lenders"
+			}
+		},
+		"Default": {
+			"EFolder": {
+				"Credit Report": "Credit Report"
+			},
+			"Email": {},
+			"Form": {
+				"Trust Account": "Trust Account"
+			},
+			"Internet": {
+				"Arch": "https://ratestar.archmi.com/quote/#/login",
+				"Essent": "https://www.essent.us/"
+			},
+			"Popup": {
+				"2015 Itemization": "2015 Itemization"
+			},
+			"Pricing": {
+				"Optimal Blue": "https://www2.optimalblue.com/"
+			},
+			"Print": {},
+			"Service": {
+				"Access Lenders": "Lenders"
+			}
+		}
+	},
+	"LoanInformation": {
+		"Loan Officer": {
+			"3": "",
+			"VASUMM.X23": "",
+			"1401": "",
+			"19": "",
+			"799": ""
+		},
+		"Default": {
+			"3": "",
+			"VASUMM.X23": "",
+			"1401": "",
+			"19": "",
+			"799": ""
+		}
 	}
+}
 }


### PR DESCRIPTION
We have a client that would like to use this plugin but needs to be able to lock it down by persona/userid.

It appears that hasn't been implemented yet and I didn't see a way to add it without causing a breaking change for anyone already using it.

Here is my proposed solution.

Also, kudos man, this is awesome stuff!!!!